### PR TITLE
change $pre for better compatibility

### DIFF
--- a/OnlyOffice/app.php
+++ b/OnlyOffice/app.php
@@ -25,8 +25,7 @@ class OnlyOfficePlugin extends PluginBase{
 			}
 		}
 		$http_type = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')) ? 'https://' : 'http://';
-		$dir = explode('/',__DIR__);
-		$pre = $http_type.$_SERVER['HTTP_HOST'].'/'.$dir[count($dir)-2].'/'.$dir[count($dir)-1];
+		$pre = $http_type.$_SERVER['HTTP_HOST'].substr(__DIR__,strlen($_SERVER["DOCUMENT_ROOT"]));
 		$config = $this->getConfig();
 		if (strlen($config['apiServer']) > 0) {
 		    header('Location:'.$pre.'/office.php?path='.rawurlencode($path).'&api='.$config['apiServer']);

--- a/OnlyOffice/office.php
+++ b/OnlyOffice/office.php
@@ -1,7 +1,7 @@
 <?php
     $http_type = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')) ? 'https://' : 'http://';
     $dir = explode('/',__DIR__);
-    $pre = $http_type.$_SERVER['HTTP_HOST'].'/'.$dir[count($dir)-2].'/'.$dir[count($dir)-1];
+    $pre = $http_type.$_SERVER['HTTP_HOST'].substr(__DIR__,strlen($_SERVER["DOCUMENT_ROOT"]));
     function jsAPI(){ // js api 地址
         // docker run -i -t -d -p 666:80 onlyoffice/documentserver
         if (strpos($_GET['api'],"api.js")) {
@@ -14,10 +14,10 @@
         echo md5_file($_GET['path']);
     }
     function pathFile(){ // 本地硬盘路径转下载路径
-        echo $GLOBALS["pre"]."/file.php?path=" . $_GET['path'];
+        echo $GLOBALS["pre"]."/file.php?path=".$_GET['path'];
     }
     function cbUrl(){ // 文件保存回调
-        echo $GLOBALS["pre"]."/save.php?path=" . $_GET['path'];
+        echo $GLOBALS["pre"]."/save.php?path=".$_GET['path'];
     }
     function fileInfo($type){ // 获取文件名，后缀
         echo pathinfo($_GET['path'],$type);

--- a/OnlyOffice/test.php
+++ b/OnlyOffice/test.php
@@ -11,7 +11,7 @@ $w = array("doc", "docm", "docx", "dot", "dotm", "dotx", "epub", "fodt", "htm", 
 $p = array("fodp", "odp", "pot", "potm", "potx", "pps", "ppsm", "ppsx", "ppt", "pptm", "pptx");
 $s = array("csv", "fods", "ods", "xls", "xlsm", "xlsx", "xlt", "xltm", "xltx");
 if (in_array($type,$w)) {
-    echo "类型: 文档".$type;
+    echo "类型: 文档"     .$type;
 } elseif (in_array($type,$p)){
     echo "类型: 幻灯片".$type;
 } elseif (in_array($type,$s)){
@@ -23,6 +23,9 @@ echo "<br/>";
 $http_type = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')) ? 'https://' : 'http://';
 echo "域名: ".$http_type.$_SERVER['HTTP_HOST'];
 echo "<br/>";
-$dir = explode('/',__DIR__);
-echo "下载地址: ".$http_type.$_SERVER['HTTP_HOST'].'/'.$dir[count($dir)-2].'/'.$dir[count($dir)-1].'/file.php?path='.$path;
+echo "URI: ".__DIR__."<br/>";
+echo "浏览器UA: ".$_SERVER["HTTP_USER_AGENT"]."<br/>";
+echo "网站根目录: ".$_SERVER["DOCUMENT_ROOT"]."<br/>";
+echo "插件目录: ".substr(__DIR__,strlen($_SERVER["DOCUMENT_ROOT"]))."<br/>";
+echo "下载地址: ".$http_type.$_SERVER['HTTP_HOST'].substr(__DIR__,strlen($_SERVER["DOCUMENT_ROOT"])).'/file.php?path='.$path;
 ?>


### PR DESCRIPTION
原本的路径是`'/'.$dir[count($dir)-2].'/'.$dir[count($dir)-1]`，如果KodExplorer部署在网站子目录，插件便不能用。我在想，把插件路径改成`substr(__DIR__,strlen($_SERVER["DOCUMENT_ROOT"]))`，通用性会更好一些。